### PR TITLE
Add simple tests for remaining untests pull_request.py functions

### DIFF
--- a/tests/test_pull_request.py
+++ b/tests/test_pull_request.py
@@ -4,9 +4,9 @@ Tests for the functions in tamarack.pull_request.py
 '''
 
 # Import Python libs
+from unittest.mock import MagicMock, patch
 import os
 import pytest
-from unittest.mock import MagicMock, patch
 
 # Import Tornado libs
 import tornado.httpclient
@@ -38,7 +38,8 @@ class TestAssignReviewers(tornado.testing.AsyncTestCase):
                            'base': {'ref': 'master'}},
                       'repository':
                           {'url': 'https://api.github.com/repos/rallytime/tamarack'}}
-        with patch('tamarack.pull_request._get_code_owners', MagicMock(return_value=['tamarack-bot'])):
+        with patch('tamarack.pull_request._get_code_owners',
+                   MagicMock(return_value=['tamarack-bot'])):
             try:
                 yield tamarack.pull_request.assign_reviewers(
                     event_data,
@@ -157,8 +158,9 @@ class TestCreatePRComment(tornado.testing.AsyncTestCase):
         '''
         Tests that the GitHub api request was made to post a comment.
         '''
-        event_data = {'pull_request':
-                          {'issue_url': 'https://api.github.com/repos/rallytime/tamarack/issues/25'}}
+        event_data = {
+            'pull_request':
+                {'issue_url': 'https://api.github.com/repos/rallytime/tamarack/issues/25'}}
         try:
             yield tamarack.pull_request.create_pr_comment(
                 event_data,

--- a/tests/test_pull_request.py
+++ b/tests/test_pull_request.py
@@ -6,8 +6,10 @@ Tests for the functions in tamarack.pull_request.py
 # Import Python libs
 import os
 import pytest
+from unittest.mock import MagicMock, patch
 
 # Import Tornado libs
+import tornado.httpclient
 import tornado.testing
 import tornado.web
 
@@ -15,6 +17,37 @@ import tornado.web
 import tamarack.pull_request
 
 GITHUB_TEST_TOKEN = os.environ.get('GITHUB_TEST_TOKEN') or ''
+
+
+class TestAssignReviewers(tornado.testing.AsyncTestCase):
+    '''
+    TestCase for the assign_reviewers function
+    '''
+
+    @pytest.mark.skipif(not GITHUB_TEST_TOKEN,
+                        reason='A GitHub API token with permission to request reviewers '
+                               'is required to run this test.')
+    @tornado.testing.gen_test
+    def test_reviewer_assigned(self):
+        '''
+        Tests that an API call is made to assign a reviewer
+        '''
+        event_data = {'number': 19,
+                      'pull_request':
+                          {'url': 'https://api.github.com/repos/rallytime/tamarack/pulls/19',
+                           'base': {'ref': 'master'}},
+                      'repository':
+                          {'url': 'https://api.github.com/repos/rallytime/tamarack'}}
+        with patch('tamarack.pull_request._get_code_owners', MagicMock(return_value=['tamarack-bot'])):
+            try:
+                yield tamarack.pull_request.assign_reviewers(
+                    event_data,
+                    GITHUB_TEST_TOKEN
+                )
+            except tornado.httpclient.HTTPError:
+                assert False
+
+            assert True
 
 
 class TestGetCodeOwners:
@@ -110,6 +143,32 @@ class TestGetPRFileNames(tornado.testing.AsyncTestCase):
                           {'url': 'https://api.github.com/repos/saltstack/salt/pulls/49517'}}
         files = yield tamarack.pull_request.get_pr_file_names(event_data, GITHUB_TEST_TOKEN)
         assert files == ['salt/modules/yumpkg.py']
+
+
+class TestCreatePRComment(tornado.testing.AsyncTestCase):
+    '''
+    TestCase for the create_pr_comment function
+    '''
+
+    @pytest.mark.skipif(not GITHUB_TEST_TOKEN,
+                        reason='A GitHub API token is required to run this test.')
+    @tornado.testing.gen_test
+    def test_comment(self):
+        '''
+        Tests that the GitHub api request was made to post a comment.
+        '''
+        event_data = {'pull_request':
+                          {'issue_url': 'https://api.github.com/repos/rallytime/tamarack/issues/25'}}
+        try:
+            yield tamarack.pull_request.create_pr_comment(
+                event_data,
+                GITHUB_TEST_TOKEN,
+                'This comment was brought to you by Tamarack\'s automated tests. :]'
+            )
+        except tornado.httpclient.HTTPError:
+            assert False
+
+        assert True
 
 
 class TestGetPROwner:


### PR DESCRIPTION
The new tests are simple, but will help catch major problems in refactors.

The new tests cover the following fuctions:
  - assign_reviewers
  - create_pr_comment

Refs #1