### PR TITLE
Add "create" event handling for branch creation

### DIFF
--- a/tamarack/server.py
+++ b/tamarack/server.py
@@ -27,6 +27,7 @@ import tamarack.event_processor
 
 HOOK_SECRET_KEY = os.environ.get('HOOK_SECRET_KEY')
 GITHUB_TOKEN = os.environ.get('GITHUB_TOKEN')
+SLACK_WEBHOOK_URL = os.environ.get('SLACK_WEBHOOK_URL')
 
 LOG = logging.getLogger(__name__)
 
@@ -98,6 +99,14 @@ def _check_env_vars():
             'The bot was started without a GitHub authentication token.\n'
             'Please set the GITHUB_TOKEN environment variable: '
             '"export GITHUB_TOKEN=your_token".'
+        )
+
+    if SLACK_WEBHOOK_URL is None:
+        LOG.warning(
+            'The bot was started without an optional Slack Webhook URL.\n'
+            'In order to interact with Slack, the webhook must be set.\n'
+            'Please set the SLACK_WEBHOOK_URL environment variable: '
+            '"export SLACK_WEBHOOK_URL=your_slack_webhook_url".'
         )
 
     return check_ok

--- a/tamarack/slack.py
+++ b/tamarack/slack.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+'''
+Contains functions required for interacting with Slack. The main function
+used is the ``api_request`` function. This function handles the GET/POST
+interactions to Slack.
+'''
+
+# Import Python libs
+import json
+import logging
+import os
+
+# Import Tornado libs
+from tornado import gen
+import tornado.httpclient
+
+
+LOG = logging.getLogger(__name__)
+SLACK_WEBHOOK_URL = os.environ.get('SLACK_WEBHOOK_URL')
+
+
+@gen.coroutine
+def api_request(method='GET', headers=None, post_data=None):
+    '''
+    The main function used to interact with the Slack API. This function
+    performs the actual requests to Slack when responding to various events.
+
+    method
+        Type of HTTP method. Defaults to ``GET``.
+
+    headers
+        HTTP Headers needed to make the request. Defaults to ``None``.
+
+        Note: There are a couple of hard-coded defaults defined here presently.
+        This is subject to change once configuration files or additional
+        environment variables are defined. ``Content-Type`` defaults to
+        ``application/json``, as required by Slack.
+
+    post_data
+        The data to pass to the Slack API request. Defaults to ``None``.
+
+        This data will change based on the type of request made. For example,
+        sending text to a Slack channel requires something like the following:
+        ``'{"text": "My comment message."}'``. Other API calls may require
+        different options and structures.
+
+    '''
+    if headers is None:
+        headers = {'Content-Type': 'application/json'}
+
+    data = None
+    if post_data:
+        data = json.dumps(post_data)
+        data = data.encode('utf-8')
+
+    http_client = tornado.httpclient.AsyncHTTPClient()
+    request = tornado.httpclient.HTTPRequest(
+        SLACK_WEBHOOK_URL,
+        method=method,
+        headers=headers,
+        body=data
+    )
+    yield http_client.fetch(request)

--- a/tests/test_event_processor.py
+++ b/tests/test_event_processor.py
@@ -33,6 +33,16 @@ class TestHandleEvent(tornado.testing.AsyncTestCase):
         ret = yield tamarack.event_processor.handle_event(event_data, '')
         assert ret is None
 
+    @tornado.testing.gen_test
+    def test_create_event(self):
+        '''
+        Tests that a create even is handled
+        '''
+        event_data = {'ref_type': 'foo',
+                      'ref': 'bar'}
+        ret = yield tamarack.event_processor.handle_event(event_data, '')
+        assert ret is None
+
 
 class TestHandlePullRequest(tornado.testing.AsyncTestCase):
     '''
@@ -72,4 +82,36 @@ class TestHandlePullRequest(tornado.testing.AsyncTestCase):
         event_data = {'number': 1,
                       'action': 'foo'}
         ret = yield tamarack.event_processor.handle_pull_request(event_data, '')
+        assert ret is None
+
+
+class TestHandleCreateEvent(tornado.testing.AsyncTestCase):
+    '''
+    TestCase for the handle_create_event function
+    '''
+
+    @tornado.testing.gen_test
+    def test_new_branch(self):
+        '''
+        Tests that a branch pushed to GitHub calls sends a slack message
+        '''
+        slack_url = tamarack.slack.SLACK_WEBHOOK_URL
+        tamarack.slack.SLACK_WEBHOOK_URL = 'https://slack.com/api/api.test'
+
+        event_data = {'ref_type': 'branch',
+                      'ref': 'test-branch-name'}
+        ret = yield tamarack.event_processor.handle_create_event(event_data)
+        assert ret is None
+
+        # Reset variables for clean tests
+        tamarack.slack.SLACK_WEBHOOK_URL = slack_url
+
+    @tornado.testing.gen_test
+    def test_unknown_event(self):
+        '''
+        Tests that create events other than "branch" are ignored.
+        '''
+        event_data = {'ref_type': 'foo',
+                      'ref': 'bar'}
+        ret = yield tamarack.event_processor.handle_create_event(event_data)
         assert ret is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,12 +5,34 @@ Tests for the functions in tamarack.server.py
 
 # Import Python libs
 from unittest.mock import MagicMock, patch
+import pytest
 
 # Import Tornado libs
 import tornado.web
 
 # Import Tamarack libs
 import tamarack.server
+
+
+@pytest.fixture(scope='module')
+def preserve_globals(request):
+    '''
+    Test fixture used to preserve global variables
+    '''
+    hook_secret = tamarack.server.HOOK_SECRET_KEY
+    gh_token = tamarack.server.GITHUB_TOKEN
+
+    tamarack.server.HOOK_SECRET_KEY = None
+    tamarack.server.GITHUB_TOKEN = None
+
+    def restore_globals():
+        '''
+        Restore the previously defined global variables
+        '''
+        tamarack.server.HOOK_SECRET_KEY = hook_secret
+        tamarack.server.GITHUB_TOKEN = gh_token
+
+    request.addfinalizer(restore_globals)
 
 
 class TestValidateGitHubSignature:
@@ -26,7 +48,7 @@ class TestValidateGitHubSignature:
         setattr(self.request, 'headers', {'X-Hub-Signature': 'foo=bar'})
         assert tamarack.server.validate_github_signature(self.request) is False
 
-    def test_valid_signature(self):
+    def test_valid_signature(self, preserve_globals):  # pylint: disable=W0613,W0621
         '''
         Tests that a valid signature works and returns True
         '''
@@ -37,32 +59,27 @@ class TestValidateGitHubSignature:
         setattr(self.request, 'body', 'hello world'.encode('utf-8'))
         assert tamarack.server.validate_github_signature(self.request) is True
 
-        # Reset variables for clean tests
-        tamarack.server.HOOK_SECRET_KEY = None
-
 
 class TestCheckEnvVars:
     '''
     TestCase for the _check_env_vars function.
     '''
 
-    def test_missing_hook_secret(self):
+    def test_missing_hook_secret(self, preserve_globals):  # pylint: disable=W0613,W0621
         '''
         Tests that False is returned when the HOOK_SECRET_KEY is missing.
         '''
+        tamarack.server.HOOK_SECRET_KEY = None
         assert tamarack.server._check_env_vars() is False
 
-    def test_missing_gh_token(self):
+    def test_missing_gh_token(self, preserve_globals):  # pylint: disable=W0613,W0621
         '''
         Tests that False is returned when GITHUB_TOKEN is missing.
         '''
         tamarack.server.HOOK_SECRET_KEY = 'foo'
         assert tamarack.server._check_env_vars() is False
 
-        # Reset variable for clean tests
-        tamarack.server.HOOK_SECRET_KEY = None
-
-    def test_env_variables_present(self):
+    def test_env_variables_present(self, preserve_globals):  # pylint: disable=W0613,W0621
         '''
         Tests that True is returned when all the required environment variables
         are present.
@@ -70,10 +87,6 @@ class TestCheckEnvVars:
         tamarack.server.HOOK_SECRET_KEY = 'foo'
         tamarack.server.GITHUB_TOKEN = 'bar'
         assert tamarack.server._check_env_vars() is True
-
-        # Reset variables for clean tests
-        tamarack.server.HOOK_SECRET_KEY = None
-        tamarack.server.GITHUB_TOKEN = None
 
 
 class TestSetupLogging:
@@ -97,9 +110,16 @@ class TestSetupLogging:
         assert tamarack.server._setup_logging() is None
 
     @patch('os.path.exists', MagicMock(return_value=True))
-    @patch('os.environ.get', MagicMock(return_value='WARN'))
     def test_logging_success(self):
         '''
         Tests that logging was set up correctly.
+        '''
+        assert tamarack.server._setup_logging() is None
+
+    @patch('os.path.exists', MagicMock(return_value=True))
+    @patch('os.environ.get', MagicMock(return_value='WARN'))
+    def test_success_valid_level(self):
+        '''
+        Tests that logging was set up correctly when passing a log_level.
         '''
         assert tamarack.server._setup_logging() is None

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+'''
+Tests for the functions in tamarack.slack.py
+'''
+
+# Import Tornado libs
+import tornado.testing
+
+# Import Tamarack libs
+import tamarack.slack
+
+
+class TestAPIRequest(tornado.testing.AsyncTestCase):
+    '''
+    TestCase for the api_request function
+    '''
+
+    @tornado.testing.gen_test
+    def test_request_no_data(self):
+        '''
+        Tests that a basic API call is made to Slack with minimal information
+        '''
+        slack_url = tamarack.slack.SLACK_WEBHOOK_URL
+        tamarack.slack.SLACK_WEBHOOK_URL = 'https://slack.com/api/api.test'
+        ret = yield tamarack.slack.api_request(
+            method='POST',
+            post_data={'text': 'foo'}
+        )
+        assert ret is None
+
+        # Reset variables for clean tests
+        tamarack.slack.SLACK_WEBHOOK_URL = slack_url


### PR DESCRIPTION
This feature adds slack integration to POST incoming webhooks as a slack notification when a new branch is created.

This also fixes up a couple of test issues found while debugging. I added a test fixture in order to keep all of the environment variables clean if they were set before running the tests. We want to preserve those settings and restore them after the test executes.

TO USE:
- Configure Slack to use [Incoming Webhooks](https://api.slack.com/incoming-webhooks)
- Set the provided Webhook URL from Slack as the `SLACK_WEBHOOK_URL` variable, just as you would set your github token, etc.
- Restart the bot

Tamarack will send a message to the configured Slack workspace and channel like so:
```
A new branch named `<whatever>` was created in the Salt repo.
```